### PR TITLE
fix: update conditions for building documentation and uploading artifacts based on release status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,11 +81,11 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build documentation
-        if: success()
+        if: steps.semantic.outputs.new-release-published == 'true'
         run: pnpm run docs:build
 
       - name: Upload build artifacts
-        if: success()
+        if: steps.semantic.outputs.new-release-published == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: prerelease-artifacts-${{ github.ref_name }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow so “Build documentation” and “Upload build artifacts” run only when a new release is published, reducing unnecessary pipeline runs and aligning outputs with actual releases.
* **Documentation**
  * Documentation builds are now triggered exclusively on new releases, ensuring published docs match released versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->