### PR TITLE
fix: update moduleResolution to 'bundler' in tsconfig.spec.json files

### DIFF
--- a/demo/tsconfig.spec.json
+++ b/demo/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../dist/out-tsc",
     "module": "commonjs",
-    "moduleResolution": "node10",
+    "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "types": ["jest", "node", "@nx/react/typings/cssmodule.d.ts", "@nx/react/typings/image.d.ts"]
   },

--- a/ui/tsconfig.spec.json
+++ b/ui/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../dist/out-tsc",
     "module": "commonjs",
-    "moduleResolution": "node10",
+    "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "types": ["jest", "node"]
   },

--- a/www/tsconfig.spec.json
+++ b/www/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../dist/out-tsc",
     "module": "commonjs",
-    "moduleResolution": "node10",
+    "moduleResolution": "bundler",
     "jsx": "react",
     "types": ["jest", "node"]
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Switched TypeScript module resolution used in test configurations to a bundler-based strategy across the codebase, affecting how modules are resolved during test compilation. No changes to runtime behavior or control flow.
* **Chores**
  * Updated configuration settings to standardize test build behavior across projects.
* **Notes**
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->