### PR TITLE
fix: remove package-lock.json from paths added in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,6 @@ jobs:
           add-paths: |
             CHANGELOG.md
             package.json
-            package-lock.json
             pnpm-lock.yaml
 
       - name: Build documentation


### PR DESCRIPTION
x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated release automation to align with the current package manager. Pre-release pull requests will now include the pnpm lockfile and exclude the npm lockfile.
  - This streamlines dependency tracking in release PRs and reduces noise for reviewers.
  - No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->